### PR TITLE
fix: correct setter method name for JSON deserialization

### DIFF
--- a/src/main/java/org/zakaria/whatsappsenderselenium/model/MessageRequest.java
+++ b/src/main/java/org/zakaria/whatsappsenderselenium/model/MessageRequest.java
@@ -1,5 +1,7 @@
 package org.zakaria.whatsappsenderselenium.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
@@ -81,7 +83,8 @@ public class MessageRequest {
      *
      * @param isGroup {@code true} if the recipient is a group, {@code false} otherwise
      */
-    public void setIsGroup(boolean isGroup) {
+    @JsonProperty("isGroup")
+    public void setGroup(boolean isGroup) {
         this.isGroup = isGroup;
     }
 }

--- a/src/main/java/org/zakaria/whatsappsenderselenium/model/MessageRequest.java
+++ b/src/main/java/org/zakaria/whatsappsenderselenium/model/MessageRequest.java
@@ -81,7 +81,7 @@ public class MessageRequest {
      *
      * @param isGroup {@code true} if the recipient is a group, {@code false} otherwise
      */
-    public void setGroup(boolean isGroup) {
+    public void setIsGroup(boolean isGroup) {
         this.isGroup = isGroup;
     }
 }


### PR DESCRIPTION
Renamed `setGroup` to `setIsGroup` to follow JavaBean naming convention and allow Jackson to properly map the JSON field `isGroup`.